### PR TITLE
add replay-from / stream-id to the datastream protocol

### DIFF
--- a/types.go
+++ b/types.go
@@ -28,6 +28,10 @@ const (
 	MessageTypePartial MessageType = "partial"
 	MessageTypeDelete  MessageType = "delete"
 	MessageTypeError   MessageType = "error"
+	// MessageTypeReload tells the client its replay window has aged out of the
+	// server's retention and it must drop local state and do a full reload
+	// rather than trust a partial replay. Carries no data.
+	MessageTypeReload  MessageType = "reload"
 	MessageTypeUnknown MessageType = "unknown"
 )
 
@@ -36,6 +40,12 @@ type DataStreamReq struct {
 	Action     Action            `json:"action"`
 	EntityType EntityType        `json:"entity_type"`
 	Keys       map[string]string `json:"keys,omitempty"`
+	// ReplayFrom, when set on a subscribe request, asks the server to replay the
+	// messages published after this stream ID (the StreamID of the last message
+	// the client processed) so a reconnecting client can catch up on missed
+	// changes instead of doing a full reload. If the server can no longer
+	// guarantee a complete replay it responds with MessageTypeReload.
+	ReplayFrom *string `json:"replay_from,omitempty"`
 }
 
 // DataStreamBaseReq wraps the request data
@@ -49,6 +59,10 @@ type DataStreamResp struct {
 	EntityID    *string         `json:"entity_id"`
 	EntityType  string          `json:"entity_type"`
 	MessageType MessageType     `json:"message_type"`
+	// StreamID is the server-side stream ID of the underlying message. Clients
+	// record the latest value and send it back as ReplayFrom on reconnect.
+	// Absent on the initial snapshot / subscription confirmation.
+	StreamID *string `json:"stream_id,omitempty"`
 }
 
 // DataStreamError represents an error message from the datastream


### PR DESCRIPTION
Protocol mirror of the schematic-api replay-from-offset work (SchematicHQ/schematic-api#5851), so a reconnecting datastream client can replay missed changes instead of a full reload.

- `DataStreamReq.ReplayFrom` — subscribe-time resume token (the last `StreamID` the client processed).
- `DataStreamResp.StreamID` — per-message resume token the client records and sends back.
- `MessageTypeReload` — server signal that the replay window aged out of retention; client must drop state and full-reload.

Additive `omitempty` fields, wire-compatible with peers that don't yet send/read them. Consumed by the replicator in a follow-up PR.